### PR TITLE
add args to piCamera creation so non pi version can access height/width

### DIFF
--- a/piCamera.go
+++ b/piCamera.go
@@ -64,6 +64,7 @@ func New(parentCtx context.Context, args *RaspividArgs) (*PiCamera, error) {
 		command:  cmd,
 		stdOut:   stdOut,
 		rwMutext: new(sync.RWMutex),
+		args:     args,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes nil pointer at https://github.com/technomancers/piCamera/blob/master/start.go#L45